### PR TITLE
Add workspace scaffolding and code-server CWD override in startup script

### DIFF
--- a/terraform/scripts/code-server-startup.sh
+++ b/terraform/scripts/code-server-startup.sh
@@ -54,20 +54,6 @@ EOF
 # (documented in systemd.exec(5)) :contentReference[oaicite:2]{index=2}
 systemctl daemon-reload   # reload unit files now that the drop-in exists
 
-# 3. (Optional) VS Code setting so detached terminals also land here
-sudo -u "${TARGET_USER}" bash -c '
-SETTINGS_DIR="$HOME/.local/share/code-server/User"
-mkdir -p "$SETTINGS_DIR"
-if [ -f "$SETTINGS_DIR/settings.json" ]; then
-  jq ". + {\"terminal.integrated.cwd\": \"'"${WORKSPACE_DIR}"'\"}" \
-     "$SETTINGS_DIR/settings.json" >"$SETTINGS_DIR/settings.tmp" && \
-     mv "$SETTINGS_DIR/settings.tmp" "$SETTINGS_DIR/settings.json"
-else
-  echo "{\"terminal.integrated.cwd\": \"'"${WORKSPACE_DIR}"'\"}" \
-       >"$SETTINGS_DIR/settings.json"
-fi
-'
-
 # --- Development Tools Installation (as target user) ---
 # Install uv (Python package manager)
 sudo -u "$TARGET_USER" bash -c 'curl -LsSf https://astral.sh/uv/install.sh | sh'

--- a/terraform/scripts/code-server-startup.sh
+++ b/terraform/scripts/code-server-startup.sh
@@ -37,6 +37,37 @@ apt-get -y install --no-install-recommends \
 export HOME=/root
 curl -fsSL https://code-server.dev/install.sh | sh
 
+# --- Workspace scaffold + code-server CWD override ---
+WORKSPACE_DIR="/home/${TARGET_USER}/workspace"
+
+# 1.  Create language buckets (idempotent)
+mkdir -p "${WORKSPACE_DIR}"/{python,rust,js,data,notebooks,scratch,bin,projects}
+chown -R "${TARGET_USER}:${TARGET_USER}" "${WORKSPACE_DIR}"
+
+# 2.  Tell systemd to start code-server in that path
+mkdir -p /etc/systemd/system/code-server@${TARGET_USER}.service.d
+cat <<EOF >/etc/systemd/system/code-server@${TARGET_USER}.service.d/override.conf
+[Service]
+WorkingDirectory=${WORKSPACE_DIR}
+EOF
+# WorkingDirectory= sets the process CWD for the service and its children
+# (documented in systemd.exec(5)) :contentReference[oaicite:2]{index=2}
+systemctl daemon-reload   # reload unit files now that the drop-in exists
+
+# 3. (Optional) VS Code setting so detached terminals also land here
+sudo -u "${TARGET_USER}" bash -c '
+SETTINGS_DIR="$HOME/.local/share/code-server/User"
+mkdir -p "$SETTINGS_DIR"
+if [ -f "$SETTINGS_DIR/settings.json" ]; then
+  jq ". + {\"terminal.integrated.cwd\": \"'"${WORKSPACE_DIR}"'\"}" \
+     "$SETTINGS_DIR/settings.json" >"$SETTINGS_DIR/settings.tmp" && \
+     mv "$SETTINGS_DIR/settings.tmp" "$SETTINGS_DIR/settings.json"
+else
+  echo "{\"terminal.integrated.cwd\": \"'"${WORKSPACE_DIR}"'\"}" \
+       >"$SETTINGS_DIR/settings.json"
+fi
+'
+
 # --- Development Tools Installation (as target user) ---
 # Install uv (Python package manager)
 sudo -u "$TARGET_USER" bash -c 'curl -LsSf https://astral.sh/uv/install.sh | sh'


### PR DESCRIPTION
- Created a structured workspace directory for various programming languages.
- Configured systemd to set the working directory for the code-server service.
- Added optional VS Code settings to ensure detached terminals open in the specified workspace directory.