### PR TITLE
Enhance tagging strategy for compute instances and resources

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -79,6 +79,8 @@ No modules.
 | <a name="input_default_region"></a> [default\_region](#input\_default\_region) | Default GCP region where resources are managed | `string` | `"europe-southwest1"` | no |
 | <a name="input_default_zone"></a> [default\_zone](#input\_default\_zone) | Default GCP zone where resources are managed | `string` | `"europe-southwest1-b"` | no |
 | <a name="input_deployer_sa_name"></a> [deployer\_sa\_name](#input\_deployer\_sa\_name) | Email of the service account to impersonate | `string` | `"devmesh-infra-admin"` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Deployment environment for resources | `string` | `"dev"` | no |
+| <a name="input_owner"></a> [owner](#input\_owner) | Owner of the deployed resources | `string` | `"devmesh-team"` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID where resources are managed | `string` | n/a | yes |
 | <a name="input_tailscale_api_key"></a> [tailscale\_api\_key](#input\_tailscale\_api\_key) | API key for authenticating with Tailscale API | `string` | n/a | yes |
 | <a name="input_tailscale_secret_id"></a> [tailscale\_secret\_id](#input\_tailscale\_secret\_id) | Tailscale secret ID | `string` | `"TAILSCALE_AUTHKEY"` | no |

--- a/terraform/compute.tf
+++ b/terraform/compute.tf
@@ -18,6 +18,7 @@ resource "google_compute_instance" "bastion" {
   zone                = var.us_zone
   machine_type        = var.bastion_machine_type
   deletion_protection = false
+  tags                = ["allow-tailscale-udp", "dev-instance"]
 
   boot_disk {
     source      = google_compute_disk.bastion.self_link
@@ -46,9 +47,10 @@ resource "google_compute_instance" "bastion" {
     enable_vtpm                 = true
   }
 
-  labels = {
+  labels = merge(local.standard_labels, {
+    component        = "bastion"
     dependency_group = random_pet.global_version.id
-  }
+  })
 }
 
 resource "google_compute_instance" "code" {
@@ -56,17 +58,18 @@ resource "google_compute_instance" "code" {
   name         = "${var.base_name}-code"
   zone         = var.default_zone
   machine_type = var.code_machine_type
-  tags         = ["allow-tailscale-udp"]
+  tags         = ["allow-tailscale-udp", "dev-instance"]
 
   boot_disk {
     source      = google_compute_disk.code.self_link
     auto_delete = false
   }
 
-  labels = {
+  labels = merge(local.standard_labels, {
+    component             = "code"
     goog-ops-agent-policy = "v2-x86-template-1-4-0"
     dependency_group      = random_pet.global_version.id
-  }
+  })
 
   metadata = {
     enable-osconfig = "TRUE"
@@ -97,7 +100,7 @@ resource "google_compute_instance" "workstation" {
   name         = "${var.base_name}-workstation"
   zone         = var.default_zone
   machine_type = var.workstation_machine_type
-  tags         = ["allow-tailscale-udp"]
+  tags         = ["allow-tailscale-udp", "dev-instance"]
 
   boot_disk {
     source      = google_compute_disk.workstation.self_link
@@ -126,8 +129,9 @@ resource "google_compute_instance" "workstation" {
     enable_vtpm                 = true
   }
 
-  labels = {
+  labels = merge(local.standard_labels, {
+    component        = "workstation"
     dependency_group = random_pet.global_version.id
-  }
+  })
 
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -9,4 +9,13 @@ locals {
 
   # Load Tailscale ACL
   tailscale_acl = file("${path.module}/../rules/tailscale-acl.jsonc")
+
+  # Standard labels for all resources
+  standard_labels = {
+    project     = var.base_name
+    environment = var.environment
+    owner       = var.owner
+    managed_by  = "terraform"
+    version     = random_pet.global_version.id
+  }
 }

--- a/terraform/networking.tf
+++ b/terraform/networking.tf
@@ -13,17 +13,19 @@ data "google_compute_subnetwork" "default_us" {
 }
 
 resource "google_compute_router" "nat_router_esw1" {
-  depends_on = [google_project_service.compute]
-  name       = "nat-router-esw1"
-  network    = data.google_compute_network.default.self_link
-  project    = var.project_id
-  region     = var.default_region
+  depends_on  = [google_project_service.compute]
+  name        = "nat-router-esw1"
+  network     = data.google_compute_network.default.self_link
+  project     = var.project_id
+  region      = var.default_region
+  description = "NAT Router for code and workstation instances. Managed by Terraform."
 }
 
 resource "google_compute_router" "nat_router_us" {
-  depends_on = [google_project_service.compute]
-  name       = "nat-router"
-  network    = data.google_compute_network.default.self_link
-  project    = var.project_id
-  region     = var.us_region
+  depends_on  = [google_project_service.compute]
+  name        = "nat-router"
+  network     = data.google_compute_network.default.self_link
+  project     = var.project_id
+  region      = var.us_region
+  description = "NAT Router for bastion instance. Managed by Terraform."
 }

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -8,10 +8,10 @@ resource "google_compute_disk" "bastion" {
   size                      = var.bastion_disk_size
   type                      = var.default_disk_types["bastion"]
 
-  labels = {
+  labels = merge(local.standard_labels, {
+    component        = "bastion"
     dependency_group = random_pet.global_version.id
-  }
-
+  })
 }
 
 resource "google_compute_disk" "code" {
@@ -24,10 +24,10 @@ resource "google_compute_disk" "code" {
   size                      = var.code_disk_size
   type                      = var.default_disk_types["code"]
 
-  labels = {
+  labels = merge(local.standard_labels, {
+    component        = "code"
     dependency_group = random_pet.global_version.id
-  }
-
+  })
 }
 
 resource "google_compute_disk" "workstation" {
@@ -40,8 +40,8 @@ resource "google_compute_disk" "workstation" {
   size                      = var.workstation_disk_size
   type                      = var.default_disk_types["workstation"]
 
-  labels = {
+  labels = merge(local.standard_labels, {
+    component        = "workstation"
     dependency_group = random_pet.global_version.id
-  }
-
+  })
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -135,3 +135,19 @@ variable "tailscale_secret_id" {
   description = "Tailscale secret ID"
   default     = "TAILSCALE_AUTHKEY"
 }
+
+# -----------------------------------------------------------
+# Tagging variables
+# -----------------------------------------------------------
+
+variable "environment" {
+  type        = string
+  description = "Deployment environment for resources"
+  default     = "dev"
+}
+
+variable "owner" {
+  type        = string
+  description = "Owner of the deployed resources"
+  default     = "devmesh-team"
+}


### PR DESCRIPTION
- Added 'dev-instance' tag to bastion, code, and workstation instances.
- Updated labels for compute instances and disks to use standard labels with component information.
- Introduced standard labels in locals.tf for consistent resource tagging.
- Added descriptions to NAT router resources for better clarity in networking.tf.
- Documented new variables for environment and owner in variables.tf.