### PR TITLE
Remove Tailscale ACL, DNS, and Settings from Terraform State

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -55,10 +55,7 @@ No modules.
 | [google_service_account.code_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account.workstation_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [random_pet.global_version](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
-| [tailscale_acl.as_json](https://registry.terraform.io/providers/tailscale/tailscale/latest/docs/resources/acl) | resource |
-| [tailscale_dns_preferences.magic_dns](https://registry.terraform.io/providers/tailscale/tailscale/latest/docs/resources/dns_preferences) | resource |
 | [tailscale_tailnet_key.nodes_auth_key](https://registry.terraform.io/providers/tailscale/tailscale/latest/docs/resources/tailnet_key) | resource |
-| [tailscale_tailnet_settings.tailnet_settings](https://registry.terraform.io/providers/tailscale/tailscale/latest/docs/resources/tailnet_settings) | resource |
 | [google_compute_image.bastion](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
 | [google_compute_image.code](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
 | [google_compute_image.workstation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |

--- a/terraform/tailscale.tf
+++ b/terraform/tailscale.tf
@@ -1,16 +1,3 @@
-resource "tailscale_acl" "as_json" {
-  acl = local.tailscale_acl
-}
-
-resource "tailscale_dns_preferences" "magic_dns" {
-  magic_dns = true
-}
-
-resource "tailscale_tailnet_settings" "tailnet_settings" {
-  acls_externally_managed_on = true
-  devices_auto_updates_on    = true
-}
-
 resource "tailscale_tailnet_key" "nodes_auth_key" {
   reusable            = true
   preauthorized       = true


### PR DESCRIPTION

## Summary
Removed three Tailscale resources from Terraform state management while preserving the actual resources in Tailscale and maintaining the authentication key for node access.

## Changes
- **Removed from Terraform state**: `tailscale_acl.as_json`, `tailscale_dns_preferences.magic_dns`, `tailscale_tailnet_settings.tailnet_settings`
- **Preserved**: `tailscale_tailnet_key.nodes_auth_key` for continued node authentication
- **Updated**: `terraform/tailscale.tf` - removed resource blocks for unmanaged resources

## Impact
- Tailscale ACL, DNS preferences, and tailnet settings are no longer managed by Terraform
- External resources remain functional in Tailscale network
- Node authentication continues to work via preserved auth key
- Clean Terraform state with no pending changes

## Commands Executed
```bash
terraform state rm 'tailscale_acl.as_json'
terraform state rm 'tailscale_dns_preferences.magic_dns'  
terraform state rm 'tailscale_tailnet_settings.tailnet_settings'
```